### PR TITLE
Fix DIVADevelopmentFund issue

### DIFF
--- a/contracts/DIVADevelopmentFund.sol
+++ b/contracts/DIVADevelopmentFund.sol
@@ -46,6 +46,9 @@ contract DIVADevelopmentFund is IDIVADevelopmentFund, ReentrancyGuard {
         override
         nonReentrant
     {
+        if (!_isValidReleasePeriod(_releasePeriodInSeconds)) {
+            revert InvalidReleasePeriod();
+        }
         uint256 _depositIndex = _addNewDeposit(
             address(0),
             msg.value,
@@ -60,6 +63,9 @@ contract DIVADevelopmentFund is IDIVADevelopmentFund, ReentrancyGuard {
         uint256 _amount,
         uint256 _releasePeriodInSeconds
     ) external override nonReentrant {
+        if (!_isValidReleasePeriod(_releasePeriodInSeconds)) {
+            revert InvalidReleasePeriod();
+        }
         uint256 _depositIndex = _addNewDeposit(
             _token,
             _amount,
@@ -239,5 +245,9 @@ contract DIVADevelopmentFund is IDIVADevelopmentFund, ReentrancyGuard {
                 (_deposit.amount * (block.timestamp - _deposit.lastClaimedAt)) /
                 (_deposit.endTime - _deposit.startTime);
         }
+    }
+
+    function _isValidReleasePeriod(uint256 _releasePeriodInSeconds) private pure returns (bool) {
+        return (_releasePeriodInSeconds != 0 && _releasePeriodInSeconds <= 30*365 days);
     }
 }

--- a/contracts/DIVAOwnershipSecondary.sol
+++ b/contracts/DIVAOwnershipSecondary.sol
@@ -63,7 +63,6 @@ contract DIVAOwnershipSecondary is UsingTellor, IDIVAOwnershipSecondary {
         // 12 hours as well as the reporting timestamp
         (bytes memory _valueRetrieved, uint256 _timestampRetrieved) = 
             getDataBefore(_queryId, block.timestamp - _MIN_UNDISPUTED_PERIOD);
-
         
         // Check that data exists
         if (_timestampRetrieved == 0) {

--- a/contracts/interfaces/IDIVADevelopmentFund.sol
+++ b/contracts/interfaces/IDIVADevelopmentFund.sol
@@ -7,6 +7,10 @@ interface IDIVADevelopmentFund {
     // Thrown in `withdraw` if `msg.sender` is not the owner of DIVA protocol
     error NotDIVAOwner(address _user, address _divaOwner);
 
+    // Thrown in `deposit` if `_releasePeriodInSeconds` argument is zero or
+    // exceeds 30 years    
+    error InvalidReleasePeriod();
+
     // Thrown in `withdraw` if token addresses for indices passed are
     // different
     error DifferentTokens();

--- a/test/DIVADevelopmentFund.test.ts
+++ b/test/DIVADevelopmentFund.test.ts
@@ -467,6 +467,90 @@ describe("DIVADevelopmentFund", async function () {
       expect(depositedEvent?.args?.sender).to.eq(user1.address);
       expect(depositedEvent?.args?.depositIndex).to.eq(expectedDepositIndex);
     });
+
+    // -------------------------------------------
+    // Reverts
+    // -------------------------------------------
+
+    it("Reverts with `InvalidReleasePeriod()` if `_releasePeriodInSeconds = 0` in native asset deposits", async () => {
+      // ---------
+      // Arrange: Set invalid `_releasePeriodInSeconds`
+      // ---------
+      const releasePeriodInSecondsTest = 0;
+
+      // Set `depositAmount`
+      depositAmount = user1DepositTokenBalance.div(10);
+
+      // ---------
+      // Act & Assert: Check that the deposit operation fails
+      // ---------
+      await expect(divaDevelopmentFund
+        .connect(user1)
+        ["deposit(uint256)"](releasePeriodInSecondsTest, {
+          value: depositAmount,
+        })).to.be.revertedWith("InvalidReleasePeriod()");
+    });
+
+    it("Reverts with `InvalidReleasePeriod()` if `_releasePeriodInSeconds > 30*365 days` in native asset deposits", async () => {
+      // ---------
+      // Arrange: Set invalid `_releasePeriodInSeconds`
+      // ---------
+      const releasePeriodInSecondsTest = 30*365*86400 + 1; // 30 years + 1 second
+
+      // Set `depositAmount`
+      depositAmount = user1DepositTokenBalance.div(10);
+
+      // ---------
+      // Act & Assert: Check that the deposit operation fails
+      // ---------
+      await expect(divaDevelopmentFund
+        .connect(user1)
+        ["deposit(uint256)"](releasePeriodInSecondsTest, {
+          value: depositAmount,
+        })).to.be.revertedWith("InvalidReleasePeriod()");
+    });
+
+    it("Reverts with `InvalidReleasePeriod()` if `_releasePeriodInSeconds = 0` in ERC20 token deposits", async () => {
+      // ---------
+      // Arrange: Set invalid `_releasePeriodInSeconds`
+      // ---------
+      const releasePeriodInSecondsTest = 0;
+
+      // Set `depositAmount`
+      depositAmount = user1DepositTokenBalance.div(10);
+
+      // ---------
+      // Act & Assert: Check that the deposit operation fails
+      // ---------
+      await expect(divaDevelopmentFund
+        .connect(user1)
+        ["deposit(address,uint256,uint256)"](
+          depositTokenInstance.address,
+          depositAmount,
+          releasePeriodInSecondsTest
+        )).to.be.revertedWith("InvalidReleasePeriod()");
+    });
+
+    it("Reverts with `InvalidReleasePeriod()` if `_releasePeriodInSeconds > 30*365 days` in ERC20 token deposits", async () => {
+      // ---------
+      // Arrange: Set invalid `_releasePeriodInSeconds`
+      // ---------
+      const releasePeriodInSecondsTest = 30*365*86400 + 1; // 30 years + 1 second
+
+      // Set `depositAmount`
+      depositAmount = user1DepositTokenBalance.div(10);
+
+      // ---------
+      // Act & Assert: Check that the deposit operation fails
+      // ---------
+      await expect(divaDevelopmentFund
+        .connect(user1)
+        ["deposit(address,uint256,uint256)"](
+          depositTokenInstance.address,
+          depositAmount,
+          releasePeriodInSecondsTest
+        )).to.be.revertedWith("InvalidReleasePeriod()");
+    });
   });
 
   describe("withdraw", async () => {


### PR DESCRIPTION
Fix for issue #7.

To fix the issue, we followed the ComposableSecurity team's recommendation and disallowed `_releasePeriodInSeconds = 0` as input parameters for the `deposit` functions. Users that wish to deposit funds without a release period should directly send the funds to the contract.

This solution has the following benefits:
* **Minimal code changes:** The withdraw logic remains unchanged relative to what has been already audited. The other recommendations made in [this report](https://github.com/GuardianAudits/SolidityLabAudits/blob/main/DIVA/DivaAuditTeam4.md#-h-01-funds-could-be-stuck-in-divadevelopmentfund) are not as straightforward as they sound and would require more significant changes and more time to review.
* **Clear separation between direct deposits and deposits subject to vesting:** It feels cleaner to withdraw funds that are not subject to a vesting period via `withdrawDirectDeposit` function and all other funds via the `withdraw` function.
* It allowed us to combine it with the max condition for `_releasePeriodInSeconds` proposed in [this report](https://github.com/GuardianAudits/SolidityLabAudits/blob/main/DIVA/DivaAuditTeam4.md#-h-01-funds-could-be-stuck-in-divadevelopmentfund)