### PR TITLE
Remove zero address checks for long/short recipient

### DIFF
--- a/contracts/facets/LiquidityFacet.sol
+++ b/contracts/facets/LiquidityFacet.sol
@@ -17,9 +17,7 @@ contract LiquidityFacet is ILiquidity, ReentrancyGuard {
         // still possible.
         _isValidAddLiquidityTx(
             _poolId,
-            _collateralAmountIncr,
-            _longRecipient,
-            _shortRecipient
+            _collateralAmountIncr
         );
 
         // Transfer approved collateral token from `msg.sender` and mint position tokens
@@ -45,9 +43,7 @@ contract LiquidityFacet is ILiquidity, ReentrancyGuard {
             // still possible.
             _isValidAddLiquidityTx(
                 _argsBatchAddLiquidity[i].poolId,
-                _argsBatchAddLiquidity[i].collateralAmountIncr,
-                _argsBatchAddLiquidity[i].longRecipient,
-                _argsBatchAddLiquidity[i].shortRecipient
+                _argsBatchAddLiquidity[i].collateralAmountIncr
             );
 
             // Transfer approved collateral token from `msg.sender` and mint position tokens
@@ -96,16 +92,8 @@ contract LiquidityFacet is ILiquidity, ReentrancyGuard {
 
     function _isValidAddLiquidityTx(
         uint256 _poolId,
-        uint256 _collateralAmountIncr,
-        address _longRecipient,
-        address _shortRecipient
+        uint256 _collateralAmountIncr
     ) private view {
-        // `longRecipient` and `shortRecipient` should not be both zero address
-        // However, similar to `createContingentPool`, conscious decision to allow either `longRecipient`
-        // or `shortRecipient` to to be equal to the zero address to enable conditional burn use cases.
-        if (_longRecipient == address(0) && _shortRecipient == address(0))
-            revert ZeroLongAndShortRecipients();
-
         // Get pool params using `_poolId`
         LibDIVAStorage.PoolStorage storage ps = LibDIVAStorage._poolStorage();
         LibDIVAStorage.Pool storage _pool = ps.pools[_poolId];

--- a/contracts/interfaces/ILiquidity.sol
+++ b/contracts/interfaces/ILiquidity.sol
@@ -2,10 +2,6 @@
 pragma solidity 0.8.19;
 
 interface ILiquidity {
-    // Thrown in `addLiquidity` if both `longRecipient` and `shortRecipient`
-    // equal to the zero address.
-    error ZeroLongAndShortRecipients();
-
     // Struct for `batchAddLiquidity` function input
     struct ArgsBatchAddLiquidity {
         uint256 poolId;
@@ -56,9 +52,11 @@ interface ILiquidity {
      * @param _collateralAmountIncr Incremental collateral amount that `msg.sender`
      * is going to add to the pool expressed as an integer with collateral token decimals.
      * @param _longRecipient: Address that shall receive the long position tokens.
-     * Zero address is a valid input to enable conditional burn use cases.
+     * Any burn address except for the zero address is a valid recipient to enable conditional
+     * burn use cases. 
      * @param _shortRecipient: Address that shall receive the short position tokens.
-     * Zero address is a valid input to enable conditional burn use cases.
+     * Any burn address except for the zero address is a valid recipient to enable conditional
+     * burn use cases.
      */
     function addLiquidity(
         uint256 _poolId,

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -57,9 +57,11 @@ interface IPool {
          Choose a large number (e.g., `2**256 - 1`) for unlimited size. Input expects
          an integer with collateral token decimals.
      * - longRecipient: Address that shall receive the long position token.
-         Zero address is a valid input to enable conditional burn use cases.
+         Any burn address except for the zero address is a valid recipient to enable conditional
+         burn use cases.
      * - shortRecipient: Address that shall receive the short position token.
-     *   Zero address is a valid input to enable conditional burn use cases.
+         Any burn address except for the zero address is a valid recipient to enable conditional
+         burn use cases.
      * - permissionedERC721Token: Address of the ERC721 token that transfers are restricted to.
          Use zero address to render the position tokens permissionless.
      * @return poolId

--- a/contracts/libraries/LibDIVA.sol
+++ b/contracts/libraries/LibDIVA.sol
@@ -613,18 +613,7 @@ library LibDIVA {
             return false;
         }
 
-        // `longRecipient` and `shortRecipient` should not be both zero address
-        if (
-            _poolParams.longRecipient == address(0) &&
-            _poolParams.shortRecipient == address(0)
-        ) {
-            return false;
-        }
-
         return true;
-
-        // Note: Conscious decision to allow either `longRecipient` or `shortRecipient` to
-        // to be equal to the zero address to enable conditional burn use cases.
     }
 
     // Function to transfer collateral from msg.sender/maker to `this` and mint position token

--- a/scripts/examples/addLiquidity.ts
+++ b/scripts/examples/addLiquidity.ts
@@ -27,13 +27,13 @@ const _checkConditions = async (
   // Get current time (proxy for block timestamp)
   const now = Math.floor(Date.now() / 1000);
 
-  // Check that longRecipient and shortRecipient are not both zero
+  // Check that neither longRecipient nor shortRecipient equal to the zero address
   if (
-    longRecipient === ethers.constants.AddressZero &&
+    longRecipient === ethers.constants.AddressZero ||
     shortRecipient === ethers.constants.AddressZero
   ) {
     throw new Error(
-      "Long and short token recipient cannot be both zero address"
+      "Long or short token recipient cannot be both zero address"
     );
   }
 

--- a/scripts/examples/createContingentPool.ts
+++ b/scripts/examples/createContingentPool.ts
@@ -73,11 +73,11 @@ const _checkConditions = (
   }
 
   if (
-    longRecipient === ethers.constants.AddressZero &&
+    longRecipient === ethers.constants.AddressZero ||
     shortRecipient === ethers.constants.AddressZero
   ) {
     throw new Error(
-      "Long and short token recipient cannot be both zero address"
+      "Long or short token recipient cannot be both zero address"
     );
   }
 

--- a/test/LiquidityFacet.test.ts
+++ b/test/LiquidityFacet.test.ts
@@ -645,12 +645,13 @@ describe("LiquidityFacet", async function () {
         ).to.be.reverted;
       });
 
-      it("Reverts if both longRecipient and shortRecipient are zero address", async () => {
+      it("Reverts if longRecipient is the zero address", async () => {
         // ---------
-        // Arrange: Set longRecipient and shortRecipient to zero address
-        // ---------
-        const zeroXLongRecipient = ethers.constants.AddressZero;
-        const zeroXShortRecipient = ethers.constants.AddressZero;
+      // Arrange: Set longRecipient to zero address
+      // ---------
+      const zeroXLongRecipient = ethers.constants.AddressZero;
+      const shortRecipient = user3.address;
+      expect(shortRecipient).to.not.eq(ethers.constants.AddressZero);
 
         // ---------
         // Act & Assert: Check that adding liquidity fails
@@ -660,9 +661,30 @@ describe("LiquidityFacet", async function () {
             poolId,
             additionalCollateralAmount,
             zeroXLongRecipient, // longRecipient
+            shortRecipient // shortRecipient
+          )
+        ).to.be.revertedWith("ERC20: mint to the zero address");
+      });
+
+      it("Reverts if shortRecipient is the zero address", async () => {
+        // ---------
+        // Arrange: Set shortRecipient to zero address
+        // ---------
+        const zeroXShortRecipient = ethers.constants.AddressZero;
+        const longRecipient = user2.address;
+        expect(longRecipient).to.not.eq(ethers.constants.AddressZero);
+
+        // ---------
+        // Act & Assert: Check that adding liquidity fails
+        // ---------
+        await expect(
+          liquidityFacet.connect(user2).addLiquidity(
+            poolId,
+            additionalCollateralAmount,
+            longRecipient, // longRecipient
             zeroXShortRecipient // shortRecipient
           )
-        ).to.be.revertedWith("ZeroLongAndShortRecipients()");
+        ).to.be.revertedWith("ERC20: mint to the zero address");
       });
     });
 

--- a/test/PoolFacet.test.ts
+++ b/test/PoolFacet.test.ts
@@ -805,12 +805,12 @@ describe("PoolFacet", async function () {
       ).to.be.revertedWith("InvalidInputParamsCreateContingentPool()");
     });
 
-    it("Reverts if both longRecipient and shortRecipient are zero address", async () => {
+    it("Reverts if longRecipient is the zero address", async () => {
       // ---------
-      // Arrange: Set longRecipient and shortRecipient to zero address
+      // Arrange: Set longRecipient to zero address
       // ---------
       const zeroXLongRecipient = ethers.constants.AddressZero;
-      const zeroXShortRecipient = ethers.constants.AddressZero;
+      expect(shortRecipient).to.not.eq(ethers.constants.AddressZero);
 
       // ---------
       // Act & Assert: Check that contingent pool creation fails
@@ -828,10 +828,39 @@ describe("PoolFacet", async function () {
           dataProvider,
           capacity,
           longRecipient: zeroXLongRecipient,
+          shortRecipient,
+          permissionedERC721Token,
+        })
+      ).to.be.revertedWith("ERC20: mint to the zero address");
+    });
+
+    it("Reverts if shortRecipient is the zero address", async () => {
+      // ---------
+      // Arrange: Set shortRecipient to zero address
+      // ---------
+      const zeroXShortRecipient = ethers.constants.AddressZero;
+      expect(longRecipient).to.not.eq(ethers.constants.AddressZero);
+
+      // ---------
+      // Act & Assert: Check that contingent pool creation fails
+      // ---------
+      await expect(
+        poolFacet.connect(user1).createContingentPool({
+          referenceAsset,
+          expiryTime,
+          floor,
+          inflection,
+          cap,
+          gradient,
+          collateralAmount,
+          collateralToken,
+          dataProvider,
+          capacity,
+          longRecipient,
           shortRecipient: zeroXShortRecipient,
           permissionedERC721Token,
         })
-      ).to.be.revertedWith("InvalidInputParamsCreateContingentPool()");
+      ).to.be.revertedWith("ERC20: mint to the zero address");
     });
   });
 


### PR DESCRIPTION
Fixes isse #13 

Removed zero address checks in `createContingentPool` and `addLiquidity` as those are already part of OpenZeppelin's ERC20 token implementation.