### PR TITLE
Add `msg.sender` to `Staked` and `Unstaked` events

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2604,6 +2604,7 @@ Emitted when a DIVA token holder stakes for a protocol owner candidate.
 
 ```
 event Staked(
+    address indexed by,         // The address of the user that staked
     address indexed candidate,  // The address of the candidate that was staked for
     uint256 amount              // The DIVA token amount staked
 );
@@ -2615,6 +2616,7 @@ Emitted when a user reduces his stake for a protocol owner candidate.
 
 ```
 event Unstaked(
+    address indexed by,         // The address of the user that unstaked
     address indexed candidate,  // The address of the candidate that stake was reduced for
     uint256 amount              // The voting token amount unstaked
 );

--- a/contracts/DIVAOwnershipMain.sol
+++ b/contracts/DIVAOwnershipMain.sol
@@ -94,7 +94,7 @@ contract DIVAOwnershipMain is IDIVAOwnershipMain, ReentrancyGuard {
         _candidateToStakedAmount[_candidate] += _amount;
 
         // Log candidate and amount
-        emit Staked(_candidate, _amount);        
+        emit Staked(msg.sender, _candidate, _amount);        
     }
 
     function triggerElectionCycle() external override {    
@@ -166,7 +166,7 @@ contract DIVAOwnershipMain is IDIVAOwnershipMain, ReentrancyGuard {
         _DIVA_TOKEN.safeTransfer(msg.sender, _amount);
 
         // Log candidate and amount
-        emit Unstaked(_candidate, _amount);
+        emit Unstaked(msg.sender, _candidate, _amount);
     }
 
     function getStakedAmount(

--- a/contracts/interfaces/IDIVAOwnershipMain.sol
+++ b/contracts/interfaces/IDIVAOwnershipMain.sol
@@ -44,17 +44,19 @@ interface IDIVAOwnershipMain is IDIVAOwnershipShared {
 
     /**
      * @notice Emitted when a user stakes for a candidate.
+     * @param by The address of the user that staked.
      * @param candidate The address of the candidate that was staked for.
      * @param amount The voting token amount staked.
      */
-    event Staked(address indexed candidate, uint256 amount);
+    event Staked(address indexed by, address indexed candidate, uint256 amount);
 
     /**
      * @notice Emitted when a user reduces his stake for a candidate.
+     * @param by The address of the user that unstaked.
      * @param candidate The address of the candidate that stake was reduced for.
      * @param amount The voting token amount unstaked.
      */
-    event Unstaked(address indexed candidate, uint256 amount);
+    event Unstaked(address indexed by, address indexed candidate, uint256 amount);
 
     /**
      * @notice Emitted when a candidate triggers the election cycle.

--- a/test/DIVAOwnershipMain.test.ts
+++ b/test/DIVAOwnershipMain.test.ts
@@ -293,7 +293,7 @@ describe("DIVAOwnershipMain", async function () {
         // Events
         // -------------------------------------------
     
-        it("Emits a Staked event", async () => {
+        it("Emits a `Staked` event", async () => {
             // -------------------------------------------
             // Act: Stake
             // -------------------------------------------
@@ -306,6 +306,7 @@ describe("DIVAOwnershipMain", async function () {
             const stakedEvent = receipt.events?.find(
                 (item: any) => item.event === "Staked"
               );
+            expect(stakedEvent?.args?.by).to.eq(contractOwner.address);
             expect(stakedEvent?.args?.candidate).to.eq(contractOwner.address);
             expect(stakedEvent?.args?.amount).to.eq("1");
         })
@@ -831,7 +832,7 @@ describe("DIVAOwnershipMain", async function () {
         // Events
         // -------------------------------------------
     
-        it("Emits and `Unstaked` event", async () => {
+        it("Emits an `Unstaked` event", async () => {
             // -------------------------------------------
             // Arrange: Set amount to unstake and get user2's current stake
             // -------------------------------------------
@@ -853,6 +854,7 @@ describe("DIVAOwnershipMain", async function () {
             const unstakedEvent = receipt.events?.find(
                 (item: any) => item.event === "Unstaked"
               );
+            expect(unstakedEvent?.args?.by).to.eq(user2.address);
             expect(unstakedEvent?.args?.candidate).to.eq(user2.address);
             expect(unstakedEvent?.args?.amount).to.eq(amountToUnstake);
         })


### PR DESCRIPTION
Fixes issue #19 

We also checked whether there is a need to add `msg.sender` to other events as well for consistency reasons, but we concluded that this is not the case.