### PR TITLE
Update `getPoolParametersByAddress` function

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1676,7 +1676,7 @@ Refer to [`Pool`](#pool-struct) for the output data.
 
 ### getPoolParametersByAddress
 
-Same as [`getPoolParameters`](#getpoolparameters) but using the position token address as input instead of the `poolId`.
+Same as [`getPoolParameters`](#getpoolparameters), but the pool parameters are retrieved based on a provided position token address instead of a `poolId`. If the provided position token address does not match any pool, the function will return the default [`Pool`](#pool-struct) struct with zero values. This default struct can be identified by properties such as `collateralToken = 0x0000000000000000000000000000000000000000` or `dataProvider = 0x0000000000000000000000000000000000000000`, for example.
 
 ```js
 function getPoolParametersByAddress(

--- a/contracts/facets/GetterFacet.sol
+++ b/contracts/facets/GetterFacet.sol
@@ -29,9 +29,20 @@ contract GetterFacet is IGetter {
         override
         returns (LibDIVAStorage.Pool memory)
     {
+        // Read the `poolId` from the `PositionToken` contract
         PositionToken positionToken = PositionToken(_positionToken);
         bytes32 _poolId = positionToken.poolId();
-        return LibDIVA._poolParameters(_poolId);
+                
+        // Load pool information
+        LibDIVAStorage.Pool storage _pool = LibDIVAStorage._poolStorage().pools[_poolId];
+
+        // Return pool information only if the provided position token address is valid.
+        // Otherwise, return the default struct.
+        if (_pool.shortToken == _positionToken || _pool.longToken == _positionToken) {
+            return _pool;
+        }        
+        LibDIVAStorage.Pool memory _zeroPool;
+        return _zeroPool;
     }
 
     function getGovernanceParameters()

--- a/contracts/interfaces/IGetter.sol
+++ b/contracts/interfaces/IGetter.sol
@@ -27,8 +27,13 @@ interface IGetter {
         returns (LibDIVAStorage.Pool memory);
 
     /**
-     * @notice Same as `getPoolParameters` but using the position token
-     * address as input.
+     * @notice Same as `getPoolParameters`, but the pool parameters are
+     * retrieved based on a provided position token address instead of a `poolId`.
+     * @dev If the provided position token address does not match any pool, the
+     * function will return the default `Pool` struct with zero values. This
+     * default struct can be identified by properties such as
+     * `collateralToken = 0x0000000000000000000000000000000000000000` or
+     * `dataProvider = 0x0000000000000000000000000000000000000000`, for example.
      * @param _positionToken Position token address.
      * @return Pool struct.
      */


### PR DESCRIPTION
This PR addresses issue #41.

I have decided to return a default struct rather than reverting to have the same behavior as in `getPoolParameters` if called with an invalid `poolId`