### PR TITLE
Duplicate line in TipFacet.sol removed

### DIFF
--- a/contracts/facets/TipFacet.sol
+++ b/contracts/facets/TipFacet.sol
@@ -62,9 +62,6 @@ contract TipFacet is ITip, ReentrancyGuard {
         // Cache collateral token
         IERC20Metadata collateralToken = IERC20Metadata(_pool.collateralToken);
 
-        // Cache collateral token
-        IERC20Metadata collateralToken = IERC20Metadata(_pool.collateralToken);
-
         // Update claim mapping
         _fs.poolIdToReservedClaim[_poolId] += _amount;
 


### PR DESCRIPTION
For some reason, a line in `addTip` in `TipFacet.sol` was duplicated. This PR removes it. I the last two PRs that we merged it was correct: 
* https://github.com/divaprotocol/diva-protocol-v1/blob/c9fbff8796a7ece61df6dca64ac4657d65ea8b02/contracts/facets/TipFacet.sol#L63
* https://github.com/divaprotocol/diva-protocol-v1/blob/f2be3292d1aa0429248b1770be8961fb41ee723a/contracts/facets/TipFacet.sol#L63

![image (42)](https://github.com/divaprotocol/diva-protocol-v1/assets/37043174/3f41a47d-4fb2-4895-8a24-39f7f5afa566)
